### PR TITLE
Implement visualization for bad cuts

### DIFF
--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -105,6 +105,8 @@ namespace SliceVisualizer
         [UseConverter(typeof(ColorConverter))]
         public virtual Color ArrowColor { get; set; } = new Color(1f, 1f, 1f, 1f);
         [UseConverter(typeof(ColorConverter))]
+        public virtual Color BadDirectionColor { get; set; } = new Color(0f, 0f, 0f, 1f);
+        [UseConverter(typeof(ColorConverter))]
         public virtual Color CenterColor { get; set; } = new Color(1f, 1f, 1f, 1f);
         public virtual float CubeLifetime { get; set; } = 1f;
         public virtual float PopEnd { get; set; } = 0.1f;

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This option, when set to `Log` or `Sqrt` allows you to exaggerate small offsets,
 - `MissedAreaColor` (default: `[0.0, 0.0, 0.0, 0.5]`) -- RGBA color for the area between note center and cut line.
 - `SliceColor` (default: `[1.0, 1.0, 1.0, 1.0]`) -- RGBA color for the cut line.
 - `ArrowColor` (default: `[1.0, 1.0, 1.0, 1.0]`) -- RGBA color for the arrow image.
+- `BadDirectionColor` (default: `[0.0, 0.0, 0.0, 1.0]`) -- RGBA color for the arrow, in case you cut the note from the wrong side.
 - `CenterColor` (default: `[1.0, 1.0, 1.0, 1.0]`) -- RGBA color for the circle in the center of note.
 - `CubeLifetime` (default: 1.0) -- total lifetime of the visualization in seconds.
 - `PopEnd` (default: 0.1) -- highlight time for the visualization in seconds. set to 0.0 to disable highlighting.

--- a/SliceVisualizerController.cs
+++ b/SliceVisualizerController.cs
@@ -222,6 +222,16 @@ namespace SliceVisualizer
             return slicedBlock;
         }
 
+        static SaberType OtherSaber(SaberType saber) {
+            switch (saber)
+            {
+                case SaberType.SaberA: return SaberType.SaberB;
+                case SaberType.SaberB: return SaberType.SaberA;
+            }
+
+            throw new System.ArgumentException(string.Format("Invalid saber type: {0}!", saber));
+        }
+
         private void OnNoteCut(NoteController noteController, NoteCutInfo info)
         {
             var config = PluginConfig.Instance;
@@ -265,13 +275,14 @@ namespace SliceVisualizer
 
             var isDirectional = DirectionToRotation.ContainsKey(noteData.cutDirection);
             Color color = MyColorManager.ColorForSaberType(info.saberType);
+            Color otherCoor = MyColorManager.ColorForSaberType(OtherSaber(info.saberType));
 
             // Re-use cubes at the same column&layer to avoid UI cluttering
             var blockIndex = noteData.lineIndex + 4 * (int)noteData.noteLineLayer;
             var slicedBlock = BlockBuffer[blockIndex];
 
-            slicedBlock.SetCubeState(color, cubeX, cubeY, cubeRotation, isDirectional);
-            slicedBlock.SetSliceState(sliceOffset, sliceAngle, cubeRotation);
+            slicedBlock.SetCubeState(color, otherCoor, cubeX, cubeY, cubeRotation, isDirectional);
+            slicedBlock.SetSliceState(sliceOffset, sliceAngle, cubeRotation, info.directionOK, info.saberTypeOK);
         }
 
         private static readonly Dictionary<NoteCutDirection, float> DirectionToRotation = new Dictionary<NoteCutDirection, float>()


### PR DESCRIPTION
This implements visualization for bad cuts with the following:

- Cutting the note with incorrect saber will replace missed area color and slice color with the color of the saber that cut the note.
- Cutting the note from the wrong direction will change arrow color to black.

See the video attached:

https://user-images.githubusercontent.com/540652/103485766-69174a80-4e01-11eb-8ab7-2dafd5e58a7b.mp4


