### PR TITLE
quick fix for noodle extensions -- limit row/column indexes by modulus

### DIFF
--- a/Core/NsvController.cs
+++ b/Core/NsvController.cs
@@ -68,7 +68,9 @@ namespace SliceVisualizer.Core
         {
             // Re-use cubes at the same column & layer to avoid UI cluttering
             var noteData = noteController.noteData;
-            var blockIndex = noteData.lineIndex + 4 * (int) noteData.noteLineLayer;
+            var lineLayer = ((int) noteController.noteData.noteLineLayer % 3);
+            var lineIndex = noteController.noteData.lineIndex % 4;
+            var blockIndex = lineIndex + 4 * lineLayer;
             var slicedBlock = _slicedBlockPool[blockIndex];
             slicedBlock.SetData(noteController, noteCutInfo, noteData);
         }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "id": "SliceVisualizer",
   "name": "SliceVisualizer",
   "author": "Igor null <m1el.2027@gmail.com>",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Shows your cut data to train your accuracy",
   "gameVersion": "1.13.0",
   "dependsOn": {


### PR DESCRIPTION
A quick fix for noodle extensions -- limit block row/column to a sane range using modulus.
This should avoid unnecessary misses on noodle maps, but it's fully correct yet.
This resolves #14
